### PR TITLE
Fix incompatible pointer type in handle_sync_exception (ARM64)

### DIFF
--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -762,7 +762,7 @@ void handle_sync_exception(struct pt_regs *regs) {
   case 0x20: /* Instruction abort from lower EL */
   case 0x21: /* Instruction abort from same EL */
     printk(KERN_EMERG "Instruction abort at PC=0x%llx\n",
-           (unsigned long long)arch_context_get_pc(regs));
+           (unsigned long long)regs->pc);
     panic("Instruction abort");
     break;
 
@@ -773,13 +773,13 @@ void handle_sync_exception(struct pt_regs *regs) {
     uint64_t far;
     asm volatile("mrs %0, far_el1" : "=r"(far));
     printk(KERN_EMERG "Data abort at PC=0x%llx, FAR=0x%llx\n",
-           (unsigned long long)arch_context_get_pc(regs),
+           (unsigned long long)regs->pc,
            (unsigned long long)far);
 #elif defined(ARCH_X86_64) || defined(ARCH_X86)
     uint64_t cr2;
     asm volatile("mov %%cr2, %0" : "=r"(cr2));
     printk(KERN_EMERG "Page fault at PC=0x%llx, CR2=0x%llx\n",
-           (unsigned long long)arch_context_get_pc(regs),
+           (unsigned long long)regs->pc,
            (unsigned long long)cr2);
 #endif
     panic("Data abort");
@@ -787,14 +787,14 @@ void handle_sync_exception(struct pt_regs *regs) {
 
   case 0x00: /* Unknown reason */
     printk(KERN_EMERG "Unknown exception at PC=0x%llx\n",
-           (unsigned long long)arch_context_get_pc(regs));
+           (unsigned long long)regs->pc);
     panic("Unknown exception");
     break;
 
   default:
     printk(KERN_EMERG "Unhandled exception class 0x%x, ISS=0x%x\n", ec, iss);
     printk(KERN_EMERG "PC=0x%llx\n",
-           (unsigned long long)arch_context_get_pc(regs));
+           (unsigned long long)regs->pc);
     panic("Unhandled exception");
     break;
   }


### PR DESCRIPTION
## Summary
- `arch_context_get_pc()` expects `cpu_context_t*`, but `handle_sync_exception()` was passing it `struct pt_regs*` — the exception register frame, an unrelated struct that happens to also have a `pc` field.
- `struct pt_regs` already stores `pc` directly, so use `regs->pc` instead of the mistyped call.
- This was a hard compile error on newer Clang (22.x), blocking ARM64 kernel builds.

## Test plan
- [x] ARM64 kernel build compiles cleanly on Clang 22.x
- [x] Boots successfully in QEMU